### PR TITLE
Handle feedback prompt generation

### DIFF
--- a/RHIA_Copilot_Brief/src/app/api/v1/endpoints/feedback.py
+++ b/RHIA_Copilot_Brief/src/app/api/v1/endpoints/feedback.py
@@ -1,8 +1,9 @@
+from typing import Any
+
+from app.graph.feedback_graph import feedback_graph
+from app.models.user_pref import UserPreferences
 from fastapi import APIRouter
 from pydantic import BaseModel
-from typing import Dict, Any
-from app.graph.brief_generator import brief_graph
-from app.models.user_pref import UserPreferences
 
 router = APIRouter()
 
@@ -12,7 +13,7 @@ class FeedbackRequest(BaseModel):
     user_feedback: str
     previous_markdown: str
     user_preferences: UserPreferences
-    brief_data: Dict[str, Any]
+    brief_data: dict[str, Any]
 
 class FeedbackResponse(BaseModel):
     markdown: str
@@ -32,7 +33,7 @@ async def revise_section(payload: FeedbackRequest):
         "brief_data": payload.brief_data
     }
 
-    result = await brief_graph.ainvoke(state)
+    result = await feedback_graph.ainvoke(state)
 
     return FeedbackResponse(
         markdown=result["draft"],

--- a/RHIA_Copilot_Brief/src/app/graph/feedback_graph.py
+++ b/RHIA_Copilot_Brief/src/app/graph/feedback_graph.py
@@ -1,15 +1,15 @@
-from langgraph.graph import StateGraph
+from app.graph.nodes.feedback_llm_executor import FeedbackLLMExecutor
+from app.graph.nodes.feedback_prompt_builder import FeedbackPromptBuilder
 from app.graph.state import BriefState
-from app.graph.nodes.prompt_builder import PromptBuilder
-from app.graph.nodes.llm_executor import LLMExecutor
+from langgraph.graph import StateGraph
 
 # Graphe simplifié pour la reformulation après feedback utilisateur
 
 graph = StateGraph(BriefState)
 
 # Étapes
-graph.add_node("build_feedback_prompt", PromptBuilder())
-graph.add_node("call_llm", LLMExecutor())
+graph.add_node("build_feedback_prompt", FeedbackPromptBuilder())
+graph.add_node("call_llm", FeedbackLLMExecutor())
 
 # Transitions
 graph.set_entry_point("build_feedback_prompt")

--- a/RHIA_Copilot_Brief/src/app/graph/nodes/feedback_llm_executor.py
+++ b/RHIA_Copilot_Brief/src/app/graph/nodes/feedback_llm_executor.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from app.services.llm_agent import LLMAgent
+
+agent = LLMAgent()
+
+
+class FeedbackLLMExecutor:
+    """Node LangGraph: call the agent to revise a section."""
+
+    async def __call__(self, state: dict[str, Any]) -> dict[str, Any]:
+        return await agent.revise_section(state)
+

--- a/RHIA_Copilot_Brief/src/app/graph/nodes/feedback_prompt_builder.py
+++ b/RHIA_Copilot_Brief/src/app/graph/nodes/feedback_prompt_builder.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from app.services.prompt_builder import build_feedback_prompt
+
+
+class FeedbackPromptBuilder:
+    """Node LangGraph: build feedback prompt."""
+
+    def __call__(self, state: dict[str, Any]) -> dict[str, Any]:
+        prompt = build_feedback_prompt(
+            section_id=state["section_id"],
+            user_feedback=state["user_feedback"],
+            previous_output=state["previous_output"],
+            brief_data=state.get("brief_data", {}),
+            user_preferences=state.get("user_preferences", {}),
+        )
+        return {**state, "prompt": prompt}
+


### PR DESCRIPTION
## Summary
- use `feedback_graph` in feedback API endpoint
- generate feedback prompt via new `FeedbackPromptBuilder`
- execute revision through `FeedbackLLMExecutor` node

## Testing
- `ruff check src/app/api/v1/endpoints/feedback.py src/app/graph/feedback_graph.py src/app/graph/nodes/feedback_llm_executor.py src/app/graph/nodes/feedback_prompt_builder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c77d35694832591d1351ea6f09107