### PR TITLE
Fix brief validation flow

### DIFF
--- a/src/components/brief/SectionGenerator.tsx
+++ b/src/components/brief/SectionGenerator.tsx
@@ -88,8 +88,13 @@ const SectionGenerator: React.FC<SectionGeneratorProps> = ({
     }
   };
 
-  const handleValidate = () => {
+  const handleValidate = async () => {
     setIsValidated(true);
+    try {
+      await briefBackendApi.storeSectionApproval(sectionId, generatedMarkdown);
+    } catch (err) {
+      console.error('Erreur lors de la validation:', err);
+    }
     onSectionComplete(sectionId, generatedMarkdown);
   };
 

--- a/src/services/briefBackendApi.ts
+++ b/src/services/briefBackendApi.ts
@@ -1,7 +1,10 @@
 
 import { v4 as uuidv4 } from 'uuid';
 
-const BRIEF_API_BASE = 'https://rhia-copilot-dashboard.onrender.com';
+const BRIEF_API_BASE = (
+  import.meta.env.VITE_API_BRIEF_URL ||
+  'https://rhia-copilot-dashboard.onrender.com'
+).replace(/\/$/, '');
 
 export interface UserPreferences {
   sections: boolean[]; // 18 sections
@@ -138,6 +141,29 @@ export class BriefBackendApi {
     }
 
     return response.json();
+  }
+
+  async storeSectionApproval(
+    sectionId: string,
+    markdown: string,
+    status: string = 'approved'
+  ): Promise<void> {
+    const response = await fetch(`${BRIEF_API_BASE}/v1/approval`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        session_id: this.sessionId,
+        section_id: sectionId,
+        markdown,
+        status
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error("Erreur lors de l'enregistrement de la validation");
+    }
   }
 
   async getFinalBrief(): Promise<string> {


### PR DESCRIPTION
## Summary
- use `VITE_API_BRIEF_URL` when calling the backend
- add API helper to store section approval
- call the new helper when validating a section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d9dc0d1388325b26409711db93191