### PR TITLE
Fix section id handling

### DIFF
--- a/RHIA_Copilot_Brief/src/app/api/v1/endpoints/approval.py
+++ b/RHIA_Copilot_Brief/src/app/api/v1/endpoints/approval.py
@@ -1,13 +1,15 @@
 from fastapi import APIRouter
 from app.models.section import SectionApproval
 from app.redis_client import get_session_data, set_session_data
+from app.core.constants import SECTION_SLUGS_TO_LABELS
 
 router = APIRouter()
 
 @router.post("/approval")
 async def store_section_approval(payload: SectionApproval):
     approvals = await get_session_data(payload.session_id, "approvals") or {}
-    approvals[payload.section_id] = {
+    section_name = SECTION_SLUGS_TO_LABELS.get(payload.section_id, payload.section_id)
+    approvals[section_name] = {
         "markdown": payload.markdown,
         "status": payload.status,
     }

--- a/RHIA_Copilot_Brief/src/app/core/constants.py
+++ b/RHIA_Copilot_Brief/src/app/core/constants.py
@@ -23,6 +23,33 @@ SECTION_IDS: Final[list[str]] = [
     "Processus de recrutement"
 ]
 
+# Correspondance entre libellés visibles et identifiants techniques
+SECTION_LABELS_TO_SLUGS: Final[dict[str, str]] = {
+    "Titre & Job Family": "titre_job_family",
+    "Contexte & Business Case": "contexte",
+    "Finalité/Mission": "finalite_mission",
+    "Objectifs & KPIs": "objectifs_kpis",
+    "Responsabilités clés": "responsabilites_cles",
+    "Périmètre budgétaire & managérial": "perimetre_budgetaire",
+    "Environnement & contraintes": "environnement_contraintes",
+    "Compétences & exigences": "competences_exigences",
+    "Qualifications & expériences": "qualifications_experiences",
+    "Employee Value Proposition": "employee_value_proposition",
+    "Perspectives d’évolution": "perspectives_evolution",
+    "Rémunération & avantages": "remuneration_avantages",
+    "Cadre contractuel": "cadre_contractuel",
+    "Mesure de la performance & cadence": "performance_cadence",
+    "Parties prenantes & RACI": "parties_prenantes_raci",
+    "Inclusion, conformité & sécurité": "inclusion_conformite",
+    "Onboarding & développement": "onboarding_developpement",
+    "Processus de recrutement": "processus_recrutement",
+}
+
+# Mapping inverse pour retrouver le libellé à partir de l'identifiant technique
+SECTION_SLUGS_TO_LABELS: Final[dict[str, str]] = {
+    slug: label for label, slug in SECTION_LABELS_TO_SLUGS.items()
+}
+
 # Langues supportées
 LANGUAGES: Final[list[str]] = ["fr", "en"]
 

--- a/RHIA_Copilot_Brief/src/app/graph/nodes/mapper.py
+++ b/RHIA_Copilot_Brief/src/app/graph/nodes/mapper.py
@@ -1,6 +1,6 @@
 from difflib import SequenceMatcher
 from typing import Optional, Tuple
-from app.core.constants import SECTION_IDS
+from app.core.constants import SECTION_IDS, SECTION_SLUGS_TO_LABELS
 
 from typing import Literal
 
@@ -73,8 +73,19 @@ class SectionMapper:
         return labels.get(section_id, section_id.replace("_", " ").capitalize())
     
     def __call__(self, state: dict) -> dict:
-        section_id = state.get("current_section")
-        section_name = SECTION_IDS[section_id]
+        """Ajoute le libellé de section normalisé dans l'état."""
+        section_key = state.get("current_section")
+
+        if isinstance(section_key, int):
+            # Index direct dans la liste canonique
+            section_name = SECTION_IDS[section_key]
+        elif isinstance(section_key, str):
+            # Identifiant technique (slug) ou libellé déjà explicite
+            section_name = SECTION_SLUGS_TO_LABELS.get(section_key, section_key)
+        else:
+            # Valeur inattendue : on la renvoie telle quelle
+            section_name = str(section_key)
+
         return {**state, "section_id": section_name}
 
 


### PR DESCRIPTION
## Summary
- add mapping between UI slugs and canonical section labels
- improve SectionMapper to support slug identifiers
- store approvals using canonical labels

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f1a6127d48325a0bcb6bf0aa37262