### PR TITLE
Fix job_function retrieval

### DIFF
--- a/RHIA_Copilot_Brief/src/app/api/v1/endpoints/generate.py
+++ b/RHIA_Copilot_Brief/src/app/api/v1/endpoints/generate.py
@@ -7,6 +7,12 @@ from app.models.user_pref import UserPreferences
 router = APIRouter()
 
 class GenerateRequest(BaseModel):
+    """Payload for the /generate endpoint.
+
+    * ``brief_data`` is a mapping where each key is a section slug and the value
+      is the data saved for that section.
+    """
+
     session_id: str
     section_id: str
     user_preferences: UserPreferences

--- a/RHIA_Copilot_Brief/src/app/graph/nodes/rag_retriever.py
+++ b/RHIA_Copilot_Brief/src/app/graph/nodes/rag_retriever.py
@@ -9,12 +9,14 @@ class RagRetriever:
             brief_data = state["brief_data"]
             user_preferences = state["user_preferences"]
 
-            job_function = brief_data.get("job_function", "").strip()
+            job_function = brief_data.get(section_id, {}).get("job_function", "").strip()
             seniority = user_preferences.seniority.strip()
             language = user_preferences.language.strip()
 
             if not job_function:
-                raise ValueError("Champ 'job_function' manquant dans brief_data")
+                raise ValueError(
+                    f"Champ 'job_function' manquant dans brief_data[{section_id}]"
+                )
 
             chunks = await retrieve_chunks(
                 section=section_id,

--- a/src/components/brief/BriefGenerationStep.tsx
+++ b/src/components/brief/BriefGenerationStep.tsx
@@ -72,9 +72,9 @@ const BriefGenerationStep: React.FC<BriefGenerationStepProps> = ({
       const titleSectionData = await briefBackendApi.getSectionData("Titre & Job Family");
       const jobFunction = titleSectionData?.job_function || titleSectionData?.job_title || "Poste non défini";
 
-      // Préparer brief_data avec la structure exacte attendue
-      const briefData = {
-        job_function: jobFunction
+      // Préparer brief_data : chaque clé correspond au slug de la section
+      const briefData: BriefData = {
+        [sectionId]: { job_function: jobFunction }
       };
       
       console.log('Génération de section:', {
@@ -143,8 +143,8 @@ const BriefGenerationStep: React.FC<BriefGenerationStepProps> = ({
       const jobFunction = titleSectionData?.job_function || titleSectionData?.job_title || "Poste non défini";
 
       // Préparer brief_data avec la même structure
-      const briefData = {
-        job_function: jobFunction
+      const briefData: BriefData = {
+        [sectionId]: { job_function: jobFunction }
       };
       
       const response = await briefBackendApi.provideFeedback(

--- a/src/services/briefBackendApi.ts
+++ b/src/services/briefBackendApi.ts
@@ -12,6 +12,8 @@ export interface UserPreferences {
 }
 
 export interface BriefData {
+  // Keys are section slugs (e.g. "titre_job_family") and values hold
+  // the data previously saved for each section.
   [sectionId: string]: Record<string, any>;
 }
 


### PR DESCRIPTION
## Summary
- access `job_function` using section slug in RagRetriever
- document `brief_data` mapping in backend `GenerateRequest`
- clarify data shape in frontend API types
- send section-scoped `brief_data` for generation and feedback

## Testing
- `npm install`
- `npm run lint` *(fails: Unexpected any, other lint errors)*
- `npm run lint -- --fix` *(fails: remaining lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685f936511d08325b94c60950bf80503