### PR TITLE
Improve Qdrant chunk handling

### DIFF
--- a/RHIA_Copilot_Brief/src/app/graph/nodes/prompt_builder.py
+++ b/RHIA_Copilot_Brief/src/app/graph/nodes/prompt_builder.py
@@ -9,8 +9,8 @@ class PromptBuilder:
     def __call__(self, state: Dict[str, Any]) -> Dict[str, Any]:
         prompt = build_prompt(
             section_id=state["section_id"],
-            rag_context="\n\n".join([chunk["text"] for chunk in state.get("rag_chunks", [])]),
+            rag_chunks=state.get("rag_chunks", []),
             brief_data=state.get("brief_data", {}),
-            user_preferences=state.get("user_preferences", {})
+            user_preferences=state.get("user_preferences", {}),
         )
         return {**state, "prompt": prompt}

--- a/RHIA_Copilot_Brief/src/app/services/llm_agent.py
+++ b/RHIA_Copilot_Brief/src/app/services/llm_agent.py
@@ -11,9 +11,9 @@ class LLMAgent:
     async def generate_section(self, state: Dict[str, Any]) -> Dict[str, Any]:
         prompt = build_prompt(
             section_id=state["section_id"],
-            rag_context="\n\n".join([c["text"] for c in state.get("rag_chunks", [])]),
+            rag_chunks=state.get("rag_chunks", []),
             brief_data=state["brief_data"],
-            user_preferences=state["user_preferences"]
+            user_preferences=state["user_preferences"],
         )
 
         response = await call_llm(prompt)

--- a/RHIA_Copilot_Brief/src/app/services/llm_orchestrator.py
+++ b/RHIA_Copilot_Brief/src/app/services/llm_orchestrator.py
@@ -15,15 +15,12 @@ async def generate_section(
     Retourne le markdown + score de confiance + log.
     """
 
-    # 1. Concatène les contextes RAG
-    context_text = "\n\n".join([c["text"] for c in chunks])
-
-    # 2. Construit le prompt dynamique (template v3)
+    # 1. Construit le prompt dynamique (template v3)
     prompt = build_prompt(
         section_id=section_id,
-        rag_context=context_text,
+        rag_chunks=chunks,
         brief_data=brief_data,
-        user_preferences=user_preferences
+        user_preferences=user_preferences,
     )
 
     # 3. Appel LLM (OpenAI ou autre orchestrateur)

--- a/RHIA_Copilot_Brief/src/app/services/prompt_builder.py
+++ b/RHIA_Copilot_Brief/src/app/services/prompt_builder.py
@@ -1,9 +1,32 @@
-from typing import Dict, Any
+from typing import Dict, Any, List
 
-def build_prompt(section_id: str, rag_context: str, brief_data: Dict[str, Any], user_preferences: Dict[str, Any]) -> str:
+def build_prompt(
+    section_id: str,
+    rag_context: str | None = None,
+    brief_data: Dict[str, Any] | None = None,
+    user_preferences: Dict[str, Any] | None = None,
+    rag_chunks: List[Dict[str, Any]] | None = None,
+) -> str:
     """
     Construit un prompt structuré pour le LLM à partir des données utilisateur + contexte RAG.
     """
+    brief_data = brief_data or {}
+    user_preferences = user_preferences or {}
+
+    if rag_chunks is not None:
+        formatted_chunks = []
+        for chunk in rag_chunks:
+            text = chunk.get("text", "")
+            metadata = chunk.get("metadata", {})
+            meta_str = ", ".join(f"{k}: {v}" for k, v in metadata.items() if k != "text")
+            if meta_str:
+                formatted_chunks.append(f"{text}\n[{meta_str}]")
+            else:
+                formatted_chunks.append(text)
+        rag_context = "\n\n".join(formatted_chunks)
+    else:
+        rag_context = rag_context or ""
+
     seniority = user_preferences.get("seniority", "Senior")
     tone = {
         "Stagiaire": "simple et accessible",


### PR DESCRIPTION
## Summary
- add async wrapper around Qdrant search
- expose rag chunks directly in prompt builder and integrate metadata
- build prompts with metadata via rag chunks
- update LLM nodes to use new prompt builder API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python -m py_compile RHIA_Copilot_Brief/src/app/services/*.py RHIA_Copilot_Brief/src/app/graph/nodes/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6860686387f08325a64a884c3a10a8a6