### PR TITLE
Limit LLM output to selected section

### DIFF
--- a/RHIA_Copilot_Brief/src/app/services/llm_agent.py
+++ b/RHIA_Copilot_Brief/src/app/services/llm_agent.py
@@ -16,7 +16,7 @@ class LLMAgent:
             user_preferences=state["user_preferences"]
         )
 
-        response = await call_llm(prompt)
+        response = await call_llm(prompt, state["section_id"])
 
         return {
             **state,
@@ -35,7 +35,7 @@ class LLMAgent:
             user_preferences=state["user_preferences"]
         )
 
-        response = await call_llm(prompt)
+        response = await call_llm(prompt, state["section_id"])
 
         return {
             **state,

--- a/RHIA_Copilot_Brief/src/app/services/llm_client.py
+++ b/RHIA_Copilot_Brief/src/app/services/llm_client.py
@@ -8,15 +8,20 @@ client = AsyncOpenAI(
     timeout=settings.llm_timeout
 )
 
-async def call_llm(prompt: str) -> dict:
+async def call_llm(prompt: str, section_id: str) -> dict:
     """
     Envoie un prompt au LLM (OpenAI) et renvoie la réponse + estimation de confiance.
     """
     try:
+        system_message = (
+            "Tu es un expert RH chargé de rédiger uniquement la section '"
+            f"{section_id}" "' d'un brief de poste. Ne génère aucune autre section."
+        )
+
         response = await client.chat.completions.create(
             model=settings.openai_model,
             messages=[
-                {"role": "system", "content": "Tu es un expert RH chargé de rédiger des briefs de poste précis, inclusifs et adaptés au niveau de séniorité."},
+                {"role": "system", "content": system_message},
                 {"role": "user", "content": prompt}
             ],
             temperature=settings.temperature,

--- a/RHIA_Copilot_Brief/src/app/services/llm_orchestrator.py
+++ b/RHIA_Copilot_Brief/src/app/services/llm_orchestrator.py
@@ -27,7 +27,7 @@ async def generate_section(
     )
 
     # 3. Appel LLM (OpenAI ou autre orchestrateur)
-    response = await call_llm(prompt=prompt)
+    response = await call_llm(prompt=prompt, section_id=section_id)
 
     return {
         "markdown": response["output"],

--- a/RHIA_Copilot_Brief/src/app/services/prompt_builder.py
+++ b/RHIA_Copilot_Brief/src/app/services/prompt_builder.py
@@ -15,7 +15,7 @@ def build_prompt(section_id: str, rag_context: str, brief_data: Dict[str, Any], 
     user_data = brief_data.get(section_id, {})
 
     return f"""
-Tu es un expert RH en charge de rédiger une section de brief de poste.
+Tu es un expert RH en charge de rédiger une seule section de brief de poste.
 Respecte les bonnes pratiques RH : clarté, inclusivité, précision.
 
 ## CONTEXTE SEMANTIQUE (issu de documents similaires)
@@ -27,10 +27,11 @@ Respecte les bonnes pratiques RH : clarté, inclusivité, précision.
 - Ton attendu : {tone}
 - Niveau : {seniority}
 - Données utilisateur : {user_data}
+- Réponds uniquement par le texte de cette section
 
 ## CONTRAINTES
 - Si une information est manquante, indique-la entre parenthèses : (à compléter)
-- Ne reformule pas les autres sections
+- Ne génère aucune autre section
 - Utilise un format strictement Markdown
 
 Commence la rédaction maintenant.
@@ -69,6 +70,7 @@ Tu es un assistant RH expert chargé de reformuler une section de brief de poste
 - Style : {tone}
 - Réécris dans un format Markdown propre
 - Ne jamais sortir du périmètre de la section
+- Réponds uniquement par le texte de cette section
 
 Commence la reformulation maintenant.
 """.strip()


### PR DESCRIPTION
## Summary
- restrict LLM system prompt to the chosen `section_id`
- update calls to `call_llm` with the section identifier
- clarify prompt builder instructions to only output the requested section

## Testing
- `npm run lint` *(fails: cannot satisfy lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_6860f6c556e483259cffb17ba2359370