### PR TITLE
Add confidence scoring pipeline

### DIFF
--- a/RHIA_Copilot_Brief/requirements.txt
+++ b/RHIA_Copilot_Brief/requirements.txt
@@ -13,6 +13,7 @@ sentence-transformers
 # === AGENTIC LLM ===
 langchain>=0.3,<0.4
 langchain-core>=0.3,<0.4
+langchain-openai>=0.1,<0.2
 langgraph>=0.2.20,<0.3
 openai>=1.30,<1.31
 #tiktoken==0.5.1

--- a/RHIA_Copilot_Brief/src/app/api/v1/endpoints/feedback.py
+++ b/RHIA_Copilot_Brief/src/app/api/v1/endpoints/feedback.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 router = APIRouter()
 
+
 class FeedbackRequest(BaseModel):
     session_id: str
     section_id: str
@@ -15,9 +16,12 @@ class FeedbackRequest(BaseModel):
     user_preferences: UserPreferences
     brief_data: dict[str, Any]
 
+
 class FeedbackResponse(BaseModel):
     markdown: str
     confidence: float
+    confidence_label: str
+
 
 @router.post("/feedback", response_model=FeedbackResponse)
 async def revise_section(payload: FeedbackRequest):
@@ -30,12 +34,13 @@ async def revise_section(payload: FeedbackRequest):
         "user_feedback": payload.user_feedback,
         "previous_output": payload.previous_markdown,
         "user_preferences": payload.user_preferences.dict(),
-        "brief_data": payload.brief_data
+        "brief_data": payload.brief_data,
     }
 
     result = await feedback_graph.ainvoke(state)
 
     return FeedbackResponse(
         markdown=result["draft"],
-        confidence=result["confidence"]
+        confidence=result["confidence"],
+        confidence_label=result.get("confidence_label", ""),
     )

--- a/RHIA_Copilot_Brief/src/app/graph/brief_generator.py
+++ b/RHIA_Copilot_Brief/src/app/graph/brief_generator.py
@@ -1,10 +1,11 @@
-from langgraph.graph import StateGraph
-from app.graph.state import BriefState
-from app.graph.nodes.rag_retriever import RagRetriever
+from app.graph.nodes.answer_scorer import AnswerScorer
+from app.graph.nodes.llm_executor import LLMExecutor
 from app.graph.nodes.mapper import SectionMapper
 from app.graph.nodes.prompt_builder import PromptBuilder
-from app.graph.nodes.llm_executor import LLMExecutor
+from app.graph.nodes.rag_retriever import RagRetriever
 from app.graph.nodes.verifier import Verifier
+from app.graph.state import BriefState
+from langgraph.graph import StateGraph
 
 # 1. Créer le graphe
 graph = StateGraph(BriefState)
@@ -14,6 +15,7 @@ graph.add_node("retrieve_chunks", RagRetriever())
 graph.add_node("map_section", SectionMapper())
 graph.add_node("build_prompt", PromptBuilder())
 graph.add_node("call_llm", LLMExecutor())
+graph.add_node("score", AnswerScorer())
 graph.add_node("verify", Verifier())
 
 # 3. Définir les transitions
@@ -21,15 +23,14 @@ graph.set_entry_point("retrieve_chunks")
 graph.add_edge("retrieve_chunks", "map_section")
 graph.add_edge("map_section", "build_prompt")
 graph.add_edge("build_prompt", "call_llm")
-graph.add_edge("call_llm", "verify")
+graph.add_edge("call_llm", "score")
+graph.add_edge("score", "verify")
 
 # 4. Condition : si confiance faible → reboucler sur build_prompt (clarification UX plus tard)
 graph.add_conditional_edges(
-    "verify",
-    lambda state: "build_prompt" if state.get("fallback_needed") else "output"
+    "verify", lambda state: "build_prompt" if state.get("fallback_needed") else "output"
 )
 
 
 # 5. Compiler le graphe
 brief_graph = graph.compile()
- 

--- a/RHIA_Copilot_Brief/src/app/graph/feedback_graph.py
+++ b/RHIA_Copilot_Brief/src/app/graph/feedback_graph.py
@@ -1,3 +1,4 @@
+from app.graph.nodes.answer_scorer import AnswerScorer
 from app.graph.nodes.feedback_llm_executor import FeedbackLLMExecutor
 from app.graph.nodes.feedback_prompt_builder import FeedbackPromptBuilder
 from app.graph.state import BriefState
@@ -10,11 +11,13 @@ graph = StateGraph(BriefState)
 # Étapes
 graph.add_node("build_feedback_prompt", FeedbackPromptBuilder())
 graph.add_node("call_llm", FeedbackLLMExecutor())
+graph.add_node("score", AnswerScorer())
 
 # Transitions
 graph.set_entry_point("build_feedback_prompt")
 graph.add_edge("build_feedback_prompt", "call_llm")
-graph.set_finish_point("call_llm")
+graph.add_edge("call_llm", "score")
+graph.set_finish_point("score")
 
 # Compilation
 feedback_graph = graph.compile()

--- a/RHIA_Copilot_Brief/src/app/graph/nodes/answer_scorer.py
+++ b/RHIA_Copilot_Brief/src/app/graph/nodes/answer_scorer.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.confidence_scoring import combine_confidences, score_answer
+
+
+class AnswerScorer:
+    async def __call__(self, state: dict[str, Any]) -> dict[str, Any]:
+        prompt = state.get("prompt", "")
+        answer = state.get("draft", "")
+        rag_score = state.get("rag_confidence", 0.0)
+        llm_base = state.get("confidence", 0.0)
+
+        eval_score = await score_answer(prompt, answer)
+        final_conf, label = combine_confidences(rag_score, llm_base, eval_score)
+
+        return {
+            **state,
+            "llm_confidence": eval_score,
+            "confidence": final_conf,
+            "confidence_label": label,
+        }

--- a/RHIA_Copilot_Brief/src/app/graph/state.py
+++ b/RHIA_Copilot_Brief/src/app/graph/state.py
@@ -1,17 +1,21 @@
-from typing import TypedDict, Optional, List, Dict, Any
+from typing import Any, TypedDict
+
 
 class BriefState(TypedDict, total=False):
     session_id: str
     section_id: str
 
-    user_preferences: Dict[str, Any]
-    brief_data: Dict[str, Any]
+    user_preferences: dict[str, Any]
+    brief_data: dict[str, Any]
 
-    rag_chunks: Optional[List[Dict[str, Any]]]
-    prompt: Optional[str]
-    draft: Optional[str]
-    confidence: Optional[float]
-    fallback_needed: Optional[bool]
+    rag_chunks: list[dict[str, Any]] | None
+    rag_confidence: float | None
+    prompt: str | None
+    draft: str | None
+    confidence: float | None
+    llm_confidence: float | None
+    confidence_label: str | None
+    fallback_needed: bool | None
 
-    user_feedback: Optional[str]
-    previous_output: Optional[str]
+    user_feedback: str | None
+    previous_output: str | None

--- a/RHIA_Copilot_Brief/src/app/models/section.py
+++ b/RHIA_Copilot_Brief/src/app/models/section.py
@@ -1,18 +1,18 @@
 from pydantic import BaseModel, Field
-from typing import Optional, List
 
 
 class DraftSectionRequest(BaseModel):
     session_id: str
     current_section: str  # ex: "Profil"
     user_preferences: dict  # temporaire (Pydantic model acceptable)
-    brief_data: dict        # idem
+    brief_data: dict  # idem
 
 
 class DraftSectionResponse(BaseModel):
     section_id: str
     markdown: str
     confidence: float
+    confidence_label: str
     fallback_needed: bool
 
 
@@ -28,6 +28,7 @@ class FeedbackRequest(BaseModel):
 class FeedbackResponse(BaseModel):
     markdown: str
     confidence: float
+    confidence_label: str
 
 
 class SectionApproval(BaseModel):
@@ -35,4 +36,3 @@ class SectionApproval(BaseModel):
     section_id: str
     markdown: str
     status: str = Field(default="approved")  # approved | rejected
- 

--- a/RHIA_Copilot_Brief/src/app/services/confidence_scoring.py
+++ b/RHIA_Copilot_Brief/src/app/services/confidence_scoring.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any
+
+from langchain.evaluation import ScoreStringEvalChain
+from langchain_openai import ChatOpenAI
+from sentence_transformers import CrossEncoder
+
+_reranker: CrossEncoder | None = None
+_score_chain: ScoreStringEvalChain | None = None
+
+
+def get_reranker() -> CrossEncoder | None:
+    global _reranker
+    if _reranker is None:
+        try:
+            _reranker = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
+        except Exception:
+            _reranker = None
+    return _reranker
+
+
+def rerank_chunks(query: str, chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    model = get_reranker()
+    if model is None:
+        return chunks
+    pairs = [[query, c.get("text", "")] for c in chunks]
+    scores = model.predict(pairs)
+    for chunk, score in zip(chunks, scores, strict=False):
+        chunk["rerank_score"] = float(score)
+    return sorted(chunks, key=lambda c: c.get("rerank_score", 0), reverse=True)
+
+
+def compute_rag_score(chunks: list[dict[str, Any]]) -> float:
+    if not chunks:
+        return 0.0
+    return sum(c.get("rerank_score", c.get("score", 0.0)) for c in chunks) / len(chunks)
+
+
+def get_score_chain() -> ScoreStringEvalChain:
+    global _score_chain
+    if _score_chain is None:
+        llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
+        _score_chain = ScoreStringEvalChain.from_llm(llm, criteria="relevance")
+    return _score_chain
+
+
+async def score_answer(prompt: str, answer: str) -> float:
+    try:
+        chain = get_score_chain()
+        result = await chain.aevaluate_strings(prediction=answer, input=prompt)
+        return float(result.get("score", 0)) / 10.0
+    except Exception:
+        return 0.0
+
+
+def combine_confidences(rag_score: float, llm_score: float, eval_score: float) -> tuple[float, str]:
+    final = (rag_score + llm_score + eval_score) / 3.0
+    if final >= 0.8:
+        label = "élevée"
+    elif final >= 0.6:
+        label = "moyenne"
+    else:
+        label = "faible"
+    return final, label

--- a/src/services/briefBackendApi.ts
+++ b/src/services/briefBackendApi.ts
@@ -1,15 +1,14 @@
-
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from "uuid";
 
 const BRIEF_API_BASE = (
   import.meta.env.VITE_API_BRIEF_URL ||
-  'https://rhia-copilot-dashboard.onrender.com'
-).replace(/\/$/, '');
+  "https://rhia-copilot-dashboard.onrender.com"
+).replace(/\/$/, "");
 
 export interface UserPreferences {
   sections: boolean[]; // 18 sections
-  language: 'fr' | 'en';
-  seniority: 'Stagiaire' | 'Junior' | 'Senior' | 'C-level';
+  language: "fr" | "en";
+  seniority: "Stagiaire" | "Junior" | "Senior" | "C-level";
 }
 
 export interface BriefData {
@@ -24,12 +23,14 @@ export interface BriefData {
 export interface GenerateResponse {
   markdown: string;
   confidence: number;
+  confidence_label: string;
   fallback_needed: boolean;
 }
 
 export interface FeedbackResponse {
   markdown: string;
   confidence: number;
+  confidence_label: string;
 }
 
 export class BriefBackendApi {
@@ -37,8 +38,8 @@ export class BriefBackendApi {
 
   constructor() {
     this.sessionId = uuidv4();
-    console.log('BriefBackendApi initialized with session ID:', this.sessionId);
-    console.log('API Base URL:', BRIEF_API_BASE);
+    console.log("BriefBackendApi initialized with session ID:", this.sessionId);
+    console.log("API Base URL:", BRIEF_API_BASE);
   }
 
   getSessionId(): string {
@@ -57,101 +58,109 @@ export class BriefBackendApi {
       session_id: this.sessionId,
       sections: preferences.sections,
       language: preferences.language,
-      seniority: preferences.seniority
+      seniority: preferences.seniority,
     };
 
     const url = `${BRIEF_API_BASE}/v1/config`;
-    
-    console.log('=== SENDING CONFIG REQUEST ===');
-    console.log('URL:', url);
-    console.log('Session ID:', this.sessionId);
-    console.log('Payload:', JSON.stringify(payload, null, 2));
+
+    console.log("=== SENDING CONFIG REQUEST ===");
+    console.log("URL:", url);
+    console.log("Session ID:", this.sessionId);
+    console.log("Payload:", JSON.stringify(payload, null, 2));
 
     try {
       const response = await fetch(url, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload),
       });
 
-      console.log('Response status:', response.status);
-      console.log('Response headers:', Object.fromEntries(response.headers.entries()));
+      console.log("Response status:", response.status);
+      console.log(
+        "Response headers:",
+        Object.fromEntries(response.headers.entries()),
+      );
 
       if (!response.ok) {
         const errorText = await response.text();
-        console.error('=== API ERROR ===');
-        console.error('Status:', response.status);
-        console.error('Error text:', errorText);
-        throw new Error(`Erreur lors de la sauvegarde des préférences: ${response.status} - ${errorText}`);
+        console.error("=== API ERROR ===");
+        console.error("Status:", response.status);
+        console.error("Error text:", errorText);
+        throw new Error(
+          `Erreur lors de la sauvegarde des préférences: ${response.status} - ${errorText}`,
+        );
       }
 
       const result = await response.json();
-      console.log('=== CONFIG SAVED SUCCESSFULLY ===');
-      console.log('Result:', result);
+      console.log("=== CONFIG SAVED SUCCESSFULLY ===");
+      console.log("Result:", result);
     } catch (error) {
-      console.error('=== FETCH ERROR ===');
-      console.error('Error:', error);
+      console.error("=== FETCH ERROR ===");
+      console.error("Error:", error);
       throw error;
     }
   }
 
   async storeUserPreferences(preferences: UserPreferences): Promise<void> {
-    console.log('storeUserPreferences called with:', preferences);
+    console.log("storeUserPreferences called with:", preferences);
     return this.sendUserPreferences(preferences);
   }
 
   /**
    * Met à jour les données d'une section spécifique du brief
    */
-  async updateBriefData(sectionId: string, data: Record<string, any>): Promise<void> {
-    console.log('Updating brief data:', { sectionId, data });
-    
+  async updateBriefData(
+    sectionId: string,
+    data: Record<string, any>,
+  ): Promise<void> {
+    console.log("Updating brief data:", { sectionId, data });
+
     const response = await fetch(`${BRIEF_API_BASE}/v1/data`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         session_id: this.sessionId,
         section_id: sectionId,
-        data
-      })
+        data,
+      }),
     });
 
     if (!response.ok) {
-      throw new Error('Erreur lors de la mise à jour des données');
+      throw new Error("Erreur lors de la mise à jour des données");
     }
   }
 
   async generateSection(
-    sectionId: string, 
-    userPreferences: UserPreferences, 
-    briefData: BriefData
+    sectionId: string,
+    userPreferences: UserPreferences,
+    briefData: BriefData,
   ): Promise<GenerateResponse> {
-    console.log('Generate section payload:', {
+    console.log("Generate section payload:", {
       session_id: this.sessionId,
       section_id: sectionId,
       user_preferences: userPreferences,
-      brief_data: briefData
+      brief_data: briefData,
     });
 
     const response = await fetch(`${BRIEF_API_BASE}/v1/generate`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         session_id: this.sessionId,
         section_id: sectionId,
         user_preferences: userPreferences,
-        brief_data: briefData
-      })
+        brief_data: briefData,
+      }),
     });
 
     if (!response.ok) {
-      throw new Error('Erreur lors de la génération de la section');
+      throw new Error("Erreur lors de la génération de la section");
     }
 
     return response.json();
@@ -162,21 +171,21 @@ export class BriefBackendApi {
     userFeedback: string,
     previousMarkdown: string,
     userPreferences: UserPreferences,
-    briefData: BriefData
+    briefData: BriefData,
   ): Promise<FeedbackResponse> {
-    console.log('Feedback payload:', {
+    console.log("Feedback payload:", {
       session_id: this.sessionId,
       section_id: sectionId,
       user_feedback: userFeedback,
       previous_markdown: previousMarkdown,
       user_preferences: userPreferences,
-      brief_data: briefData
+      brief_data: briefData,
     });
 
     const response = await fetch(`${BRIEF_API_BASE}/v1/feedback`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         session_id: this.sessionId,
@@ -184,12 +193,12 @@ export class BriefBackendApi {
         user_feedback: userFeedback,
         previous_markdown: previousMarkdown,
         user_preferences: userPreferences,
-        brief_data: briefData
-      })
+        brief_data: briefData,
+      }),
     });
 
     if (!response.ok) {
-      throw new Error('Erreur lors de la reformulation');
+      throw new Error("Erreur lors de la reformulation");
     }
 
     return response.json();
@@ -198,19 +207,19 @@ export class BriefBackendApi {
   async storeSectionApproval(
     sectionId: string,
     markdown: string,
-    status: string = 'approved'
+    status: string = "approved",
   ): Promise<void> {
     const response = await fetch(`${BRIEF_API_BASE}/v1/approval`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json'
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         session_id: this.sessionId,
         section_id: sectionId,
         markdown,
-        status
-      })
+        status,
+      }),
     });
 
     if (!response.ok) {
@@ -219,15 +228,18 @@ export class BriefBackendApi {
   }
 
   async getFinalBrief(): Promise<string> {
-    const response = await fetch(`${BRIEF_API_BASE}/v1/brief/${this.sessionId}`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'text/plain',
-      }
-    });
+    const response = await fetch(
+      `${BRIEF_API_BASE}/v1/brief/${this.sessionId}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      },
+    );
 
     if (!response.ok) {
-      throw new Error('Erreur lors de la récupération du brief final');
+      throw new Error("Erreur lors de la récupération du brief final");
     }
 
     return response.text();
@@ -238,25 +250,28 @@ export class BriefBackendApi {
    */
   async getSectionData(sectionId: string): Promise<Record<string, any> | null> {
     try {
-      console.log('Getting section data for:', sectionId);
-      
-      const response = await fetch(`${BRIEF_API_BASE}/v1/data/${this.sessionId}/${sectionId}`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        }
-      });
+      console.log("Getting section data for:", sectionId);
+
+      const response = await fetch(
+        `${BRIEF_API_BASE}/v1/data/${this.sessionId}/${sectionId}`,
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
 
       if (!response.ok) {
-        console.log('Section data not found for:', sectionId);
+        console.log("Section data not found for:", sectionId);
         return null;
       }
 
       const data = await response.json();
-      console.log('Section data retrieved:', data);
+      console.log("Section data retrieved:", data);
       return data;
     } catch (error) {
-      console.error('Erreur lors de la récupération des données:', error);
+      console.error("Erreur lors de la récupération des données:", error);
       return null;
     }
   }
@@ -273,51 +288,55 @@ export class BriefBackendApi {
     userPreferences: UserPreferences;
   }): Promise<string> {
     try {
-      console.log('Saving final brief:', briefData);
-      
+      console.log("Saving final brief:", briefData);
+
       // Créer le contenu markdown complet du brief
       const markdownContent = briefData.sections
-        .map(section => `## ${section.name}\n\n${section.content}`)
-        .join('\n\n---\n\n');
+        .map((section) => `## ${section.name}\n\n${section.content}`)
+        .join("\n\n---\n\n");
 
       // Sauvegarder dans la table ai_briefs via Supabase
-      const { supabase } = await import('@/integrations/supabase/client');
-      
+      const { supabase } = await import("@/integrations/supabase/client");
+
       // Correction: conversion explicite en JSON pour Supabase
       const briefRecord = {
         title: briefData.title,
         is_complete: true,
-        conversation_data: JSON.parse(JSON.stringify({
-          session_id: this.sessionId,
-          user_preferences: {
-            sections: briefData.userPreferences.sections,
-            language: briefData.userPreferences.language,
-            seniority: briefData.userPreferences.seniority
-          },
-          sections: briefData.sections
-        })),
-        brief_summary: JSON.parse(JSON.stringify({
-          markdown: markdownContent,
-          sections_count: briefData.sections.length,
-          created_at: new Date().toISOString()
-        }))
+        conversation_data: JSON.parse(
+          JSON.stringify({
+            session_id: this.sessionId,
+            user_preferences: {
+              sections: briefData.userPreferences.sections,
+              language: briefData.userPreferences.language,
+              seniority: briefData.userPreferences.seniority,
+            },
+            sections: briefData.sections,
+          }),
+        ),
+        brief_summary: JSON.parse(
+          JSON.stringify({
+            markdown: markdownContent,
+            sections_count: briefData.sections.length,
+            created_at: new Date().toISOString(),
+          }),
+        ),
       };
 
       const { data, error } = await supabase
-        .from('ai_briefs')
+        .from("ai_briefs")
         .insert(briefRecord)
         .select()
         .single();
 
       if (error) {
-        console.error('Erreur lors de la sauvegarde du brief:', error);
+        console.error("Erreur lors de la sauvegarde du brief:", error);
         throw new Error(`Erreur lors de la sauvegarde: ${error.message}`);
       }
 
-      console.log('Brief sauvegardé avec succès:', data);
+      console.log("Brief sauvegardé avec succès:", data);
       return data.id;
     } catch (error) {
-      console.error('Erreur lors de la sauvegarde du brief final:', error);
+      console.error("Erreur lors de la sauvegarde du brief final:", error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- score retrieved chunks and final answers
- use new answer scorer node in graph
- expose `confidence_label` via API and UI
- display labels in brief generation steps

## Testing
- `ruff check src/app/graph/nodes/answer_scorer.py src/app/services/confidence_scoring.py src/app/graph/nodes/rag_retriever.py src/app/graph/brief_generator.py src/app/graph/feedback_graph.py src/app/api/v1/endpoints/generate.py src/app/api/v1/endpoints/feedback.py src/app/models/section.py src/app/graph/state.py`
- `pytest`
- `npx tsc -p tsconfig.json`
- `npx prettier -w src/components/brief/SectionGenerator.tsx`
- `npx prettier -w src/components/brief/BriefGenerationStep.tsx`
- `npx prettier -w src/services/briefBackendApi.ts`


------
https://chatgpt.com/codex/tasks/task_e_68610970427c83258ef5de2f4ffa5abe