### PR TITLE
Add endpoint to fetch brief section data

### DIFF
--- a/RHIA_Copilot_Brief/src/app/api/v1/endpoints/data.py
+++ b/RHIA_Copilot_Brief/src/app/api/v1/endpoints/data.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter
-from typing import Dict, Any
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 router = APIRouter()
@@ -8,7 +9,7 @@ router = APIRouter()
 class DataRequest(BaseModel):
     session_id: str
     section_id: str
-    data: Dict[str, Any]
+    data: dict[str, Any]
 
 
 @router.post("/data")
@@ -26,4 +27,16 @@ async def update_brief_data(payload: DataRequest):
 
     await set_session_data(payload.session_id, "brief_data", brief_data)
     return {"status": "updated"}
- 
+
+
+@router.get("/data/{session_id}/{section_id}")
+async def get_brief_section_data(session_id: str, section_id: str):
+    """Retourne les données stockées pour une section donnée."""
+    from app.redis_client import get_session_data
+
+    brief_data = await get_session_data(session_id, "brief_data") or {}
+    section_data = brief_data.get(section_id)
+    if section_data is None:
+        raise HTTPException(status_code=404, detail="Section data not found")
+
+    return section_data


### PR DESCRIPTION
## Summary
- provide GET `/data/{session_id}/{section_id}` route in FastAPI backend
- adjust imports and format with ruff/black

## Testing
- `npm run lint` *(fails: many lint errors)*
- `black --check RHIA_Copilot_Brief/src/app/api/v1/endpoints/data.py`
- `ruff RHIA_Copilot_Brief/src/app/api/v1/endpoints/data.py`

------
https://chatgpt.com/codex/tasks/task_e_6861306c7d748325bb88d05ef091ce43